### PR TITLE
split multiple entries in one block using bibtex-parse-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "obsidian-pretty-bibtex",
 			"version": "1.0.0",
 			"license": "MIT",
+			"dependencies": {
+				"@orcid/bibtex-parse-js": "^0.0.25"
+			},
 			"devDependencies": {
 				"@types/node": "^16.11.6",
 				"@typescript-eslint/eslint-plugin": "5.29.0",
@@ -484,6 +487,11 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/@orcid/bibtex-parse-js": {
+			"version": "0.0.25",
+			"resolved": "https://registry.npmjs.org/@orcid/bibtex-parse-js/-/bibtex-parse-js-0.0.25.tgz",
+			"integrity": "sha512-n6VuG5/WjiifC1DoUzq0sUCWNSbAyRZznBgvPcY4jVZ/2eJiMv2tNUAt2NukbnFExOUa0RyTOFsqhH2MGpiLgQ=="
 		},
 		"node_modules/@types/codemirror": {
 			"version": "0.0.108",
@@ -1920,9 +1928,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -2131,9 +2139,9 @@
 			}
 		},
 		"node_modules/word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true,
 			"peer": true,
 			"engines": {
@@ -2410,6 +2418,11 @@
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
 			}
+		},
+		"@orcid/bibtex-parse-js": {
+			"version": "0.0.25",
+			"resolved": "https://registry.npmjs.org/@orcid/bibtex-parse-js/-/bibtex-parse-js-0.0.25.tgz",
+			"integrity": "sha512-n6VuG5/WjiifC1DoUzq0sUCWNSbAyRZznBgvPcY4jVZ/2eJiMv2tNUAt2NukbnFExOUa0RyTOFsqhH2MGpiLgQ=="
 		},
 		"@types/codemirror": {
 			"version": "0.0.108",
@@ -3446,9 +3459,9 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dev": true,
 			"requires": {
 				"lru-cache": "^6.0.0"
@@ -3601,9 +3614,9 @@
 			}
 		},
 		"word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true,
 			"peer": true
 		},

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
 		"obsidian": "latest",
 		"tslib": "2.4.0",
 		"typescript": "4.7.4"
+	},
+	"dependencies": {
+		"@orcid/bibtex-parse-js": "^0.0.25"
 	}
 }


### PR DESCRIPTION
I noticed that current version couldn't show multiple bib entries in one block. #2 
It could implement using [bibtex-parse-js](https://github.com/ORCID/bibtexParseJs).
I am completely layman about javascript, hope it can work in most cases : )
### Before
![image](https://github.com/sandrofigo/obsidian-pretty-bibtex/assets/42237917/f0fc9320-f2d3-4252-8908-50b887b66899)

### After
![image](https://github.com/sandrofigo/obsidian-pretty-bibtex/assets/42237917/09345461-d362-4706-9383-478c0b177926)
